### PR TITLE
Add GetTags function.

### DIFF
--- a/template_test.go
+++ b/template_test.go
@@ -315,3 +315,20 @@ func expectPanic(t *testing.T, f func()) {
 	}()
 	f()
 }
+
+func TestGetTags(t *testing.T) {
+	tags := GetTags("{{foo}} and a {{bar}} and a {{baz}}", "{{", "}}")
+	found := map[string]bool{}
+	for _, tag := range tags {
+		found[tag] = true
+	}
+	if len(found) != 3 {
+		t.Fatalf("should have 3 tags, but has %d", len(found))
+	}
+
+	for _, tag := range []string{"foo", "bar", "baz"} {
+		if !found[tag] {
+			t.Fatalf("%s not found", tag)
+		}
+	}
+}

--- a/template_test.go
+++ b/template_test.go
@@ -317,7 +317,7 @@ func expectPanic(t *testing.T, f func()) {
 }
 
 func TestGetTags(t *testing.T) {
-	tags := GetTags("{{foo}} and a {{bar}} and a {{baz}}", "{{", "}}")
+	tags := GetTags("{{foo}} and a {{bar}} and a {{baz}} and a {{foo}} again", "{{", "}}")
 	found := map[string]bool{}
 	for _, tag := range tags {
 		found[tag] = true


### PR DESCRIPTION
I'm storing templates in a database.  When users of the admin UI go to create/update a template, I want to validate that it uses only fields that my code can actually provide.  This PR adds a method for getting the names of all the tags used in a template, so I can do that validation.