### PR TITLE
Fix possible memory confusion in unsafe slice cast

### DIFF
--- a/unsafe.go
+++ b/unsafe.go
@@ -5,6 +5,7 @@ package fasttemplate
 import (
 	"reflect"
 	"unsafe"
+	"runtime"
 )
 
 func unsafeBytes2String(b []byte) string {
@@ -12,11 +13,12 @@ func unsafeBytes2String(b []byte) string {
 }
 
 func unsafeString2Bytes(s string) []byte {
+	b := make([]byte, 0)
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	bh.Data = sh.Data
+	bh.Cap = sh.Len
+	bh.Len = sh.Len
+	runtime.KeepAlive(s)
+	return b
 }

--- a/unsafe.go
+++ b/unsafe.go
@@ -5,20 +5,17 @@ package fasttemplate
 import (
 	"reflect"
 	"unsafe"
-	"runtime"
 )
 
 func unsafeBytes2String(b []byte) string {
 	return *(*string)(unsafe.Pointer(&b))
 }
 
-func unsafeString2Bytes(s string) []byte {
-	b := make([]byte, 0)
+func unsafeString2Bytes(s string) (b []byte) {
 	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	bh.Data = sh.Data
 	bh.Cap = sh.Len
 	bh.Len = sh.Len
-	runtime.KeepAlive(s)
 	return b
 }


### PR DESCRIPTION
I found an incorrect cast from `string` to `[]byte` in `unsafe.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.