### PR TITLE
add ExecuteStringStd for strings.Replacer drop-in replacement

### DIFF
--- a/template.go
+++ b/template.go
@@ -9,8 +9,9 @@ package fasttemplate
 import (
 	"bytes"
 	"fmt"
-	"github.com/valyala/bytebufferpool"
 	"io"
+
+	"github.com/valyala/bytebufferpool"
 )
 
 // ExecuteFunc calls f on each template tag (placeholder) occurrence.
@@ -76,6 +77,22 @@ func Execute(template, startTag, endTag string, w io.Writer, m map[string]interf
 	return ExecuteFunc(template, startTag, endTag, w, func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
 }
 
+// ExecuteStd works the same way as Execute, but keeps the unknown placeholders.
+// This can be used as a drop-in replacement for strings.Replacer
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// Returns the number of bytes written to w.
+//
+// This function is optimized for constantly changing templates.
+// Use Template.ExecuteStd for frozen templates.
+func ExecuteStd(template, startTag, endTag string, w io.Writer, m map[string]interface{}) (int64, error) {
+	return ExecuteFunc(template, startTag, endTag, w, func(w io.Writer, tag string) (int, error) { return keepUnknownTagFunc(w, startTag, endTag, tag, m) })
+}
+
 // ExecuteFuncString calls f on each template tag (placeholder) occurrence
 // and substitutes it with the data written to TagFunc's w.
 //
@@ -126,6 +143,20 @@ var byteBufferPool bytebufferpool.Pool
 // Use Template.ExecuteString for frozen templates.
 func ExecuteString(template, startTag, endTag string, m map[string]interface{}) string {
 	return ExecuteFuncString(template, startTag, endTag, func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
+}
+
+// ExecuteStringStd works the same way as ExecuteString, but keeps the unknown placeholders.
+// This can be used as a drop-in replacement for strings.Replacer
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// This function is optimized for constantly changing templates.
+// Use Template.ExecuteStringStd for frozen templates.
+func ExecuteStringStd(template, startTag, endTag string, m map[string]interface{}) string {
+	return ExecuteFuncString(template, startTag, endTag, func(w io.Writer, tag string) (int, error) { return keepUnknownTagFunc(w, startTag, endTag, tag, m) })
 }
 
 // Template implements simple template engine, which can be used for fast
@@ -283,6 +314,19 @@ func (t *Template) Execute(w io.Writer, m map[string]interface{}) (int64, error)
 	return t.ExecuteFunc(w, func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
 }
 
+// ExecuteStd works the same way as Execute, but keeps the unknown placeholders.
+// This can be used as a drop-in replacement for strings.Replacer
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// Returns the number of bytes written to w.
+func (t *Template) ExecuteStd(w io.Writer, m map[string]interface{}) (int64, error) {
+	return t.ExecuteFunc(w, func(w io.Writer, tag string) (int, error) { return keepUnknownTagFunc(w, t.startTag, t.endTag, tag, m) })
+}
+
 // ExecuteFuncString calls f on each template tag (placeholder) occurrence
 // and substitutes it with the data written to TagFunc's w.
 //
@@ -332,8 +376,51 @@ func (t *Template) ExecuteString(m map[string]interface{}) string {
 	return t.ExecuteFuncString(func(w io.Writer, tag string) (int, error) { return stdTagFunc(w, tag, m) })
 }
 
+// ExecuteStringStd works the same way as ExecuteString, but keeps the unknown placeholders.
+// This can be used as a drop-in replacement for strings.Replacer
+//
+// Substitution map m may contain values with the following types:
+//   * []byte - the fastest value type
+//   * string - convenient value type
+//   * TagFunc - flexible value type
+//
+// This function is optimized for frozen templates.
+// Use ExecuteStringStd for constantly changing templates.
+func (t *Template) ExecuteStringStd(m map[string]interface{}) string {
+	return t.ExecuteFuncString(func(w io.Writer, tag string) (int, error) { return keepUnknownTagFunc(w, t.startTag, t.endTag, tag, m) })
+}
+
 func stdTagFunc(w io.Writer, tag string, m map[string]interface{}) (int, error) {
 	v := m[tag]
+	if v == nil {
+		return 0, nil
+	}
+	switch value := v.(type) {
+	case []byte:
+		return w.Write(value)
+	case string:
+		return w.Write([]byte(value))
+	case TagFunc:
+		return value(w, tag)
+	default:
+		panic(fmt.Sprintf("tag=%q contains unexpected value type=%#v. Expected []byte, string or TagFunc", tag, v))
+	}
+}
+
+func keepUnknownTagFunc(w io.Writer, startTag, endTag, tag string, m map[string]interface{}) (int, error) {
+	v, ok := m[tag]
+	if !ok {
+		if _, err := w.Write(unsafeString2Bytes(startTag)); err != nil {
+			return 0, err
+		}
+		if _, err := w.Write(unsafeString2Bytes(tag)); err != nil {
+			return 0, err
+		}
+		if _, err := w.Write(unsafeString2Bytes(endTag)); err != nil {
+			return 0, err
+		}
+		return len(startTag) + len(tag) + len(endTag), nil
+	}
 	if v == nil {
 		return 0, nil
 	}

--- a/template_test.go
+++ b/template_test.go
@@ -280,6 +280,36 @@ func testExecute(t *testing.T, template, expectedOutput string) {
 	}
 }
 
+func TestExecuteStd(t *testing.T) {
+	testExecuteStd(t, "", "")
+	testExecuteStd(t, "a", "a")
+	testExecuteStd(t, "abc", "abc")
+	testExecuteStd(t, "{foo}", "xxxx")
+	testExecuteStd(t, "a{foo}", "axxxx")
+	testExecuteStd(t, "{foo}a", "xxxxa")
+	testExecuteStd(t, "a{foo}bc", "axxxxbc")
+	testExecuteStd(t, "{foo}{foo}", "xxxxxxxx")
+	testExecuteStd(t, "{foo}bar{foo}", "xxxxbarxxxx")
+
+	// unclosed tag
+	testExecuteStd(t, "{unclosed", "{unclosed")
+	testExecuteStd(t, "{{unclosed", "{{unclosed")
+	testExecuteStd(t, "{un{closed", "{un{closed")
+
+	// test unknown tag
+	testExecuteStd(t, "{unknown}", "{unknown}")
+	testExecuteStd(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxq{unexpected}{missing}barxxxx")
+}
+
+func testExecuteStd(t *testing.T, template, expectedOutput string) {
+	var bb bytes.Buffer
+	ExecuteStd(template, "{", "}", &bb, map[string]interface{}{"foo": "xxxx"})
+	output := string(bb.Bytes())
+	if output != expectedOutput {
+		t.Fatalf("unexpected output for template=%q: %q. Expected %q", template, output, expectedOutput)
+	}
+}
+
 func TestExecuteString(t *testing.T) {
 	testExecuteString(t, "", "")
 	testExecuteString(t, "a", "a")
@@ -303,6 +333,34 @@ func TestExecuteString(t *testing.T) {
 
 func testExecuteString(t *testing.T, template, expectedOutput string) {
 	output := ExecuteString(template, "{", "}", map[string]interface{}{"foo": "xxxx"})
+	if output != expectedOutput {
+		t.Fatalf("unexpected output for template=%q: %q. Expected %q", template, output, expectedOutput)
+	}
+}
+
+func TestExecuteStringStd(t *testing.T) {
+	testExecuteStringStd(t, "", "")
+	testExecuteStringStd(t, "a", "a")
+	testExecuteStringStd(t, "abc", "abc")
+	testExecuteStringStd(t, "{foo}", "xxxx")
+	testExecuteStringStd(t, "a{foo}", "axxxx")
+	testExecuteStringStd(t, "{foo}a", "xxxxa")
+	testExecuteStringStd(t, "a{foo}bc", "axxxxbc")
+	testExecuteStringStd(t, "{foo}{foo}", "xxxxxxxx")
+	testExecuteStringStd(t, "{foo}bar{foo}", "xxxxbarxxxx")
+
+	// unclosed tag
+	testExecuteStringStd(t, "{unclosed", "{unclosed")
+	testExecuteStringStd(t, "{{unclosed", "{{unclosed")
+	testExecuteStringStd(t, "{un{closed", "{un{closed")
+
+	// test unknown tag
+	testExecuteStringStd(t, "{unknown}", "{unknown}")
+	testExecuteStringStd(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxq{unexpected}{missing}barxxxx")
+}
+
+func testExecuteStringStd(t *testing.T, template, expectedOutput string) {
+	output := ExecuteStringStd(template, "{", "}", map[string]interface{}{"foo": "xxxx"})
 	if output != expectedOutput {
 		t.Fatalf("unexpected output for template=%q: %q. Expected %q", template, output, expectedOutput)
 	}


### PR DESCRIPTION
Hi @valyala !
This fixes the #20 issue and adds `ExecuteStringStd` and `ExecuteStd` funcs to your lib.
Please consider this PR when you have the time