### PR TITLE
make ExecuteStringStd to be compatible to strings.Replacer on nested tags

### DIFF
--- a/template.go
+++ b/template.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/valyala/bytebufferpool"
 )
@@ -408,6 +409,15 @@ func stdTagFunc(w io.Writer, tag string, m map[string]interface{}) (int, error) 
 }
 
 func keepUnknownTagFunc(w io.Writer, startTag, endTag, tag string, m map[string]interface{}) (int, error) {
+	if i := strings.LastIndex(tag, startTag); i >= 0 {
+		if _, err := w.Write(unsafeString2Bytes(startTag)); err != nil {
+			return 0, err
+		}
+		if _, err := w.Write(unsafeString2Bytes(tag[:i])); err != nil {
+			return 0, err
+		}
+		tag = tag[i+1:]
+	}
 	v, ok := m[tag]
 	if !ok {
 		if _, err := w.Write(unsafeString2Bytes(startTag)); err != nil {

--- a/template_test.go
+++ b/template_test.go
@@ -233,6 +233,9 @@ func TestExecuteFunc(t *testing.T) {
 	// test unknown tag
 	testExecuteFunc(t, "{unknown}", "zz")
 	testExecuteFunc(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxqzzzzbarxxxx")
+
+	// test tag inside tag
+	testExecuteFunc(t, `{"x": {foo}}`, `zz}`)
 }
 
 func testExecuteFunc(t *testing.T, template, expectedOutput string) {
@@ -269,6 +272,9 @@ func TestExecute(t *testing.T) {
 	// test unknown tag
 	testExecute(t, "{unknown}", "")
 	testExecute(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxqbarxxxx")
+
+	// test tag inside tag
+	testExecute(t, `{"x": {foo}}`, `}`)
 }
 
 func testExecute(t *testing.T, template, expectedOutput string) {
@@ -299,6 +305,9 @@ func TestExecuteStd(t *testing.T) {
 	// test unknown tag
 	testExecuteStd(t, "{unknown}", "{unknown}")
 	testExecuteStd(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxq{unexpected}{missing}barxxxx")
+
+	// test tag inside tag
+	testExecuteStd(t, `{"x": {foo}}`, `{"x": xxxx}`)
 }
 
 func testExecuteStd(t *testing.T, template, expectedOutput string) {
@@ -329,6 +338,9 @@ func TestExecuteString(t *testing.T) {
 	// test unknown tag
 	testExecuteString(t, "{unknown}", "")
 	testExecuteString(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxqbarxxxx")
+
+	// test tag inside tag
+	testExecuteString(t, `{"x": {foo}}`, `}`)
 }
 
 func testExecuteString(t *testing.T, template, expectedOutput string) {
@@ -357,6 +369,9 @@ func TestExecuteStringStd(t *testing.T) {
 	// test unknown tag
 	testExecuteStringStd(t, "{unknown}", "{unknown}")
 	testExecuteStringStd(t, "{foo}q{unexpected}{missing}bar{foo}", "xxxxq{unexpected}{missing}barxxxx")
+
+	// test tag inside tag
+	testExecuteStringStd(t, `{"x": {foo}}`, `{"x": xxxx}`)
 }
 
 func testExecuteStringStd(t *testing.T, template, expectedOutput string) {


### PR DESCRIPTION
Hi @valyala!
In #23 we added ExecuteStringStd which works as a drop-in replacement to strings.Replacer.
It worked great, but we found a missmatch on nested start/end tags. 
Here is an example:
```
{"x":"{id}"} 
```
After replacing id with strings.Replacer:
```
{"x":"1"} 
```
After replacing id with fasttemplate.ExecuteStringStd:
```
{"x":"{id}"}
```

The reason is because fasttemplate takes the first start tag it finds, but strings.Replacer takes the closest to the end tag.
So i made a PR to change the logic only in the `ExecuteStringStd` and other `*Std` funcs to make them compatible with strings.Replacer.

Please review when you have the time