### PR TITLE
Change deprecated reflect function in unsafeString2Bytes

### DIFF
--- a/unsafe.go
+++ b/unsafe.go
@@ -12,10 +12,5 @@ func unsafeBytes2String(b []byte) string {
 }
 
 func unsafeString2Bytes(s string) (b []byte) {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	bh.Data = sh.Data
-	bh.Cap = sh.Len
-	bh.Len = sh.Len
-	return b
+	return *(*[]byte)(unsafe.Pointer(&s))
 }


### PR DESCRIPTION
1. Replace deprecated reflect functions:
https://pkg.go.dev/reflect#SliceHeader
https://pkg.go.dev/reflect#StringHeader
2. Simpler - there's no need to manipulate  or  types.
3. Faster because directly convert the type without creating temporary structures